### PR TITLE
Switch from nightly toolchain to stable 1.81

### DIFF
--- a/recapn/src/alloc.rs
+++ b/recapn/src/alloc.rs
@@ -187,7 +187,7 @@ impl<'a> SegmentPtr<'a> {
     }
 
     pub const fn signed_offset_from_end(self, offset: SignedSegmentOffset) -> Self {
-        const ONE: SignedSegmentOffset = SignedSegmentOffset::new(1).unwrap();
+        const ONE: SignedSegmentOffset = SignedSegmentOffset::new_unwrap(1);
 
         self.signed_offset(ONE).signed_offset(offset)
     }
@@ -370,7 +370,7 @@ pub struct Growing<A> {
 
 impl<A> Growing<A> {
     /// The default length used for the first segment of 1024 words (8 kibibytes).
-    pub const DEFAULT_FIRST_SEGMENT_LEN: AllocLen = AllocLen::new(1024).unwrap();
+    pub const DEFAULT_FIRST_SEGMENT_LEN: AllocLen = AllocLen::new_unwrap(1024);
 
     #[inline]
     pub const fn new(first_segment: AllocLen, alloc: A) -> Self {

--- a/recapn/src/data.rs
+++ b/recapn/src/data.rs
@@ -51,10 +51,10 @@ impl<'a> Reader<'a> {
     /// If the slice is too large to be in a message, this function panics.
     #[inline]
     pub const fn from_slice(slice: &'a [u8]) -> Self {
-        Self(
-            ptr::Reader::new(slice)
-                .expect("slice is too large to be contained within a cap'n proto message"),
-        )
+        let Some(r) = ptr::Reader::new(slice) else {
+            panic!("slice is too large to be contained within a cap'n proto message")
+        };
+        Self(r)
     }
 
     #[inline]

--- a/recapn/src/lib.rs
+++ b/recapn/src/lib.rs
@@ -1,7 +1,6 @@
 //! A fast, safe, feature complete Cap'n Proto implementation for modern Rust.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "std", feature(write_all_vectored))]
 
 use crate::alloc::AllocLen;
 use core::fmt::{self, Display};

--- a/recapn/src/lib.rs
+++ b/recapn/src/lib.rs
@@ -1,7 +1,6 @@
 //! A fast, safe, feature complete Cap'n Proto implementation for modern Rust.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(const_option)]
 #![cfg_attr(feature = "std", feature(write_all_vectored))]
 
 use crate::alloc::AllocLen;

--- a/recapn/src/num.rs
+++ b/recapn/src/num.rs
@@ -50,8 +50,8 @@ impl NonZeroU29 {
     pub const MIN_VALUE: u32 = 1;
     pub const MAX_VALUE: u32 = 2u32.pow(29) - 1;
 
-    pub const MIN: Self = Self(NonZeroU32::new(Self::MIN_VALUE).unwrap());
-    pub const MAX: Self = Self(NonZeroU32::new(Self::MAX_VALUE).unwrap());
+    pub const MIN: Self = Self(unsafe { NonZeroU32::new_unchecked(Self::MIN_VALUE) });
+    pub const MAX: Self = Self(unsafe { NonZeroU32::new_unchecked(Self::MAX_VALUE) });
 
     pub const ONE: Self = Self::MIN;
 
@@ -65,6 +65,15 @@ impl NonZeroU29 {
         } else {
             None
         }
+    }
+
+    #[inline]
+    #[track_caller]
+    pub const fn new_unwrap(n: u32) -> Self {
+        let Some(s) = Self::new(n) else {
+            panic!("integer value out of range")
+        };
+        s
     }
 
     #[inline]
@@ -114,6 +123,15 @@ impl u29 {
         } else {
             None
         }
+    }
+
+    #[inline]
+    #[track_caller]
+    pub const fn new_unwrap(n: u32) -> Self {
+        let Some(s) = Self::new(n) else {
+            panic!("integer value out of range")
+        };
+        s
     }
 
     #[inline]
@@ -192,6 +210,15 @@ impl i30 {
         } else {
             None
         }
+    }
+
+    #[inline]
+    #[track_caller]
+    pub const fn new_unwrap(n: i32) -> Self {
+        let Some(s) = Self::new(n) else {
+            panic!("integer value out of range")
+        };
+        s
     }
 
     #[inline]

--- a/recapn/src/ptr.rs
+++ b/recapn/src/ptr.rs
@@ -300,7 +300,7 @@ impl StructSize {
     /// ```
     #[inline]
     pub const fn len(self) -> ObjectLen {
-        ObjectLen::new(self.total()).unwrap()
+        ObjectLen::new_unwrap(self.total())
     }
 
     /// Gets the max number of elements an struct list can contain of this struct.
@@ -334,7 +334,7 @@ impl StructSize {
             ElementCount::MAX
         } else {
             // subtract 1 for the tag ptr
-            ElementCount::new((ElementCount::MAX_VALUE - 1) / (self.total())).unwrap()
+            ElementCount::new_unwrap((ElementCount::MAX_VALUE - 1) / (self.total()))
         }
     }
 
@@ -420,7 +420,7 @@ struct Parts {
 impl Parts {
     /// Gets the segment offset of some content. This is only valid for struct and list pointers.
     pub const fn content_offset(&self) -> SignedSegmentOffset {
-        SignedSegmentOffset::new(self.lower.get() as i32 >> 2).unwrap()
+        SignedSegmentOffset::new_unwrap(self.lower.get() as i32 >> 2)
     }
 
     /// Replace the segment offset of some content
@@ -591,7 +591,7 @@ struct StructPtr {
 }
 
 impl StructPtr {
-    pub const EMPTY: Self = Self::new(SignedSegmentOffset::new(-1).unwrap(), StructSize::EMPTY);
+    pub const EMPTY: Self = Self::new(SignedSegmentOffset::new_unwrap(-1), StructSize::EMPTY);
 
     #[inline]
     pub const fn new(offset: SignedSegmentOffset, StructSize { data, ptrs }: StructSize) -> Self {
@@ -2459,7 +2459,7 @@ impl<'a> StructReader<'a, Empty> {
     ///
     /// As such any other use of this function is unsafe.
     pub const unsafe fn new_unchecked(ptr: NonNull<Word>, size: StructSize) -> Self {
-        let ptrs_offset = SegmentOffset::new(size.data as u32).unwrap();
+        let ptrs_offset = SegmentOffset::new_unwrap(size.data as u32);
 
         Self {
             data_start: ptr.cast(),
@@ -2753,7 +2753,7 @@ impl<'a> ListReader<'a, Empty> {
         element_size: ElementSize,
     ) -> Self {
         let ptr = NonNull::new_unchecked(slice.as_ptr().cast_mut());
-        Self::new_unchecked(ptr, u29::new(element_count).unwrap(), element_size)
+        Self::new_unchecked(ptr, u29::new_unwrap(element_count), element_size)
     }
 }
 
@@ -3025,7 +3025,7 @@ impl<'a> BlobReader<'a> {
     }
 }
 
-const LANDING_PAD_LEN: AllocLen = AllocLen::new(2).unwrap();
+const LANDING_PAD_LEN: AllocLen = AllocLen::new_unwrap(2);
 
 pub(crate) enum OrphanObject<'a> {
     Struct {

--- a/recapn/src/text.rs
+++ b/recapn/src/text.rs
@@ -63,16 +63,17 @@ impl<'a> Reader<'a> {
     pub const fn from_slice(s: &'a [u8]) -> Self {
         match s {
             [.., 0] => match ptr::Reader::new(s) {
-                Some(r) => Some(Self(r)),
-                None => None,
+                Some(r) => return Self(r),
+                None => {},
             },
-            _ => None,
+            _ => {},
         }
-        .expect("attempted to make invalid text blob from slice")
+
+        panic!("attempted to make invalid text blob from slice")
     }
 
     pub const fn byte_count(&self) -> ByteCount {
-        ByteCount::new(self.0.len().get()).unwrap()
+        ByteCount::new_unwrap(self.0.len().get())
     }
 
     /// The length of the text (including the null terminator)
@@ -193,7 +194,10 @@ impl<'a> Builder<'a> {
     /// Returns the bytes of the text field without the null terminator
     #[inline]
     pub const fn as_bytes(&self) -> &[u8] {
-        let (_, remainder) = self.as_bytes_with_nul().split_last().unwrap();
+        let Some((_, remainder)) = self.as_bytes_with_nul().split_last() else {
+            // Originally we would panic here, but really anything is valid
+            return &[]
+        };
         remainder
     }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-24"
+channel = "1.81"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Some minor changes, hopefully we can switch back to using `Option::unwrap` (https://github.com/rust-lang/rust/issues/67441) and `Write::write_all_vectored` (https://github.com/rust-lang/rust/issues/70436) some time soon.