### PR TITLE
migrate to single-digit dependencies

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.4"
+libfuzzer-sys = "0"
 
 [dependencies.recapn]
 path = "../recapn"

--- a/recapn-rpc/Cargo.toml
+++ b/recapn-rpc/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2021"
 
 [dependencies]
 recapn = { path = "../recapn" }
-fnv = "1.0"
-tokio = { version = "1.35", default-features = false, features = ["rt", "macros", "sync"] }
-pin-project = "1.1"
-parking_lot = "0.12"
-hashbrown = "0.14"
-scopeguard = "1.2"
+fnv = "1"
+tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync"] }
+pin-project = "1"
+parking_lot = "0"
+hashbrown = "0"
+scopeguard = "1"
 
 [dev-dependencies]
-tokio-test = "0.4"
-assert_matches2 = "0.1"
+tokio-test = "0"
+assert_matches2 = "0"
 
 [lints]
 workspace = true

--- a/recapnc/Cargo.toml
+++ b/recapnc/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 recapn = { path = "../recapn", features = [] }
-syn = { version = "2.0", features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-thiserror = "1.0"
-unicode-ident = "1.0"
-heck = "0.4"
-prettyplease = "0.2"
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
+thiserror = "1"
+unicode-ident = "1"
+heck = "0"
+prettyplease = "0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This will make sure recapnp doesn't bring outdated dependencies in. Also EW (single client) uses single-digit deps.