### PR TITLE
Add `read_from_packed_stream` to make reading individual packed messages easier

### DIFF
--- a/examples/addressbook/src/lib.rs
+++ b/examples/addressbook/src/lib.rs
@@ -5,7 +5,7 @@ pub mod gen {
 use std::io::Write;
 
 use gen::addressbook_capnp::*;
-use recapn::io::{read_packed_from_stream, PackedStream, StreamOptions};
+use recapn::io::{self, StreamOptions};
 use recapn::message::{self, Message, ReaderOptions};
 use recapn::text;
 
@@ -52,8 +52,7 @@ pub fn write_address_book<W: Write>(target: &mut W) {
 }
 
 pub fn print_address_book<W: Write>(src: &[u8], output: &mut W) -> ::recapn::Result<()> {
-    let mut message_reader = PackedStream::new(src);
-    let segments = read_packed_from_stream(&mut message_reader, StreamOptions::default()).unwrap();
+    let segments = io::read_from_packed_stream(src, StreamOptions::default()).unwrap();
     let message = message::Reader::new(&segments, ReaderOptions::default());
     let address_book = message.read_as_struct::<AddressBook>();
 

--- a/fuzz/fuzz_targets/unpacking.rs
+++ b/fuzz/fuzz_targets/unpacking.rs
@@ -2,9 +2,8 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use recapn::io::{PackedStream, StreamOptions};
+use recapn::io::StreamOptions;
 
 fuzz_target!(|data: &[u8]| {
-    let mut packed = PackedStream::new(data);
-    let _ = recapn::io::read_packed_from_stream(&mut packed, StreamOptions::default());
+    let _ = recapn::io::read_from_packed_stream(data, StreamOptions::default());
 });

--- a/recapn/src/io.rs
+++ b/recapn/src/io.rs
@@ -498,8 +498,24 @@ impl<R: io::BufRead> PackedStream<R> {
     }
 }
 
+/// Read a message from a stream in packed encoding. This creates a `PackedStream` and reads the
+/// message, flushing the packed state at the end to make sure the message is complete.
 #[cfg(feature = "std")]
-pub fn read_packed_from_stream<R: io::BufRead>(
+#[inline]
+pub fn read_from_packed_stream<R: io::BufRead>(
+    stream: R,
+    options: StreamOptions,
+) -> Result<SegmentSet<Box<[Word]>>, StreamError> {
+    let mut packed = PackedStream::new(stream);
+    let msg = read_with_packed_stream(&mut packed, options)?;
+    packed.finish()?;
+    Ok(msg)
+}
+
+/// Read a message from a `PackedStream`. This allows you to continue reading more packed
+/// data after the stream and reuse the packed state.
+#[cfg(feature = "std")]
+pub fn read_with_packed_stream<R: io::BufRead>(
     stream: &mut PackedStream<R>,
     options: StreamOptions,
 ) -> Result<SegmentSet<Box<[Word]>>, StreamError> {


### PR DESCRIPTION
In practice, having to make a `PackedStream`, call `read_packed_from_stream`, then call `.finish()` on the stream just to read a single message is really annoying. It's useful to have it be separate, but reading a single self-contained message from a stream (like a slice or something similar) is pretty common. So this changes the API slightly to make reading a single message easy.