### PR TITLE
Add recapn-port library and code generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "recapn",
     "recapnc",
     "recapn-channel",
+    "recapn-port",
     "recapn-rpc",
     "tests",
     "fuzz",

--- a/recapn-port/Cargo.toml
+++ b/recapn-port/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "recapn-port"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+recapn = { path = "../recapn" }
+
+[lints]
+workspace = true

--- a/recapn-port/schemas/rust/port.capnp
+++ b/recapn-port/schemas/rust/port.capnp
@@ -1,0 +1,31 @@
+@0x9ad88b88dff111f1;
+
+annotation name(struct, field, union, group, enum, enumerant, interface, method, param) :Text;
+
+annotation modName(struct, group, interface) :Text;
+# Rename the generated module associated with the given item.
+#
+# Note: not all items are given a module. Types without nested members will not have a module.
+
+annotation use(file) :Text;
+# Add a `use` statement to the file module with the given use tree.
+
+annotation skip(struct, group, enum, interface, field) :Void;
+# Skips generating this field or type. Generated structs will not contain this field or any
+# serialization or deserialization for the field.
+
+annotation replace(struct, group, enum, interface) :Text;
+# Do not generate a port of this type. Instead, export the given type path in the use tree.
+
+annotation with(field) :Void;
+# Overrides the type of the given pointer field with another type path.
+
+annotation attribute(struct, field, union, group, enum, enumerant, interface, method, param) :Text;
+# Applies the given attribute to the generated Rust item.
+
+annotation modAttribute(file, struct, group, interface) :Text;
+# Applies the given attribute to the associated module for the generated Rust item.
+
+annotation string(field) :Void;
+# When applied to a text field, handles the field as a UTF-8 string. Note: this can make invalid
+# UTF-8 fail to parse an entire struct.

--- a/recapn-port/src/data.rs
+++ b/recapn-port/src/data.rs
@@ -1,0 +1,89 @@
+use core::ops::{Deref, DerefMut};
+
+use recapn::ptr::{PtrBuilder, PtrReader};
+use recapn::rpc::Table;
+
+use crate::{DeserializePtr, Error, SerializePtr};
+
+/// A boxed slice of bytes that's guaranteed to fit in a Cap'n Proto message.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct Data {
+    // Invariant 1: the slice is within the max size of Cap'n Proto data.
+    inner: Box<[u8]>,
+}
+
+impl Data {
+    #[inline]
+    pub fn new(b: Box<[u8]>) -> Result<Self, Box<[u8]>> {
+        if recapn::ptr::ElementCount::try_from(b.len()).is_err() {
+            return Err(b)
+        }
+
+        Ok(Self { inner: b })
+    }
+    #[inline]
+    pub fn into_inner(this: Self) -> Box<[u8]> {
+        this.inner
+    }
+
+    #[inline]
+    pub fn from_reader(r: recapn::data::Reader<'_>) -> Self {
+        Self { inner: Box::from(&*r) }
+    }
+    #[inline]
+    pub fn as_reader(this: &Self) -> recapn::data::Reader<'_> {
+        recapn::data::Reader::from_slice(&this)
+    }
+}
+
+impl From<recapn::data::Reader<'_>> for Data {
+    #[inline]
+    fn from(value: recapn::data::Reader<'_>) -> Self {
+        Self::from_reader(value)
+    }
+}
+impl From<Data> for Box<[u8]> {
+    #[inline]
+    fn from(value: Data) -> Self {
+        Data::into_inner(value)
+    }
+}
+
+impl Deref for Data {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for Data {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T: Table> DeserializePtr<'_, T> for Data {
+    fn deserialize<E: Error>(r: &PtrReader<'_, T>) -> Result<Self, E> {
+        let text = match r.to_blob() {
+            Ok(Some(b)) => recapn::data::Reader::from(b),
+            Ok(None) => recapn::data::Reader::empty(),
+            Err(err) => return Err(E::protocol_error(err)),
+        };
+        Ok(Self::from_reader(text))
+    }
+}
+
+impl<T: Table> SerializePtr<'_, T> for Data {
+    fn serialize<E: Error>(&self, b: PtrBuilder<'_, T>) -> Result<(), E> {
+        let len = self.inner.len().try_into().unwrap();
+        let mut blob = match b.try_init_blob(len) {
+            Ok(blob) => recapn::data::Builder::from(blob),
+            Err((err, _)) => return Err(E::protocol_error(err)),
+        };
+        blob.copy_from_slice(&self.inner);
+        Ok(())
+    }
+}

--- a/recapn-port/src/lib.rs
+++ b/recapn-port/src/lib.rs
@@ -1,0 +1,221 @@
+use core::marker::PhantomData;
+
+use recapn::ptr::{PtrBuilder, PtrReader, StructBuilder, StructReader, StructSize};
+use recapn::rpc::{Capable, Table};
+
+pub mod data;
+pub mod list;
+pub mod text;
+
+pub trait Error: Sized {
+    fn custom<T: core::error::Error + 'static>(msg: T) -> Self;
+
+    fn protocol_error(err: recapn::Error) -> Self {
+        Self::custom(err)
+    }
+}
+
+impl Error for Box<dyn core::error::Error> {
+    fn custom<T: core::error::Error + 'static>(msg: T) -> Self {
+        Box::new(msg)
+    }
+
+    fn protocol_error(err: recapn::Error) -> Self {
+        Box::new(err)
+    }
+}
+
+/// An enum value that can be converted into a native typed enum.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Enum<E: recapn::ty::Enum> {
+    e: PhantomData<fn() -> E>,
+    value: u16,
+}
+
+impl<E: recapn::ty::Enum> Enum<E> {
+    #[inline]
+    pub const fn from_value(value: u16) -> Self {
+        Self { e: PhantomData, value }
+    }
+    #[inline]
+    pub fn from_type(value: E) -> Self {
+        Self::from_value(value.into())
+    }
+
+    #[inline]
+    pub fn get(self) -> Result<E, recapn::NotInSchema> {
+        self.value.try_into()
+    }
+    #[inline]
+    pub fn into_value(self) -> u16 {
+        self.value
+    }
+}
+
+pub trait Deserialize<'de, T: Table>: Sized {
+    fn deserialize<E: Error>(r: &StructReader<'de, T>) -> Result<Self, E>;
+}
+
+impl<'de, T, S> Deserialize<'de, T> for Box<S>
+where
+    T: Table,
+    S: Deserialize<'de, T>,
+{
+    #[inline]
+    fn deserialize<E: Error>(r: &StructReader<'de, T>) -> Result<Self, E> {
+        S::deserialize(r).map(Box::new)
+    }
+}
+
+pub trait DeserializePtr<'de, T: Table>: Sized {
+    fn deserialize<E: Error>(r: &PtrReader<'de, T>) -> Result<Self, E>;
+}
+
+impl<'de, T, P> DeserializePtr<'de, T> for Box<P>
+where
+    T: Table,
+    P: DeserializePtr<'de, T>,
+{
+    #[inline]
+    fn deserialize<E: Error>(r: &PtrReader<'de, T>) -> Result<Self, E> {
+        P::deserialize(r).map(Box::new)
+    }
+}
+
+impl<'de, T, P> DeserializePtr<'de, T> for Option<P>
+where
+    T: Table,
+    P: DeserializePtr<'de, T>,
+{
+    #[inline]
+    fn deserialize<E: Error>(r: &PtrReader<'de, T>) -> Result<Self, E> {
+        if r.is_null() {
+            return Ok(None)
+        }
+
+        P::deserialize(r).map(Some)
+    }
+}
+
+pub trait Serialize<'se, T: Table> {
+    const SIZE: StructSize;
+
+    fn serialize<E: Error>(&self, b: &mut StructBuilder<'se, T>) -> Result<(), E>;
+}
+
+pub trait SerializePtr<'se, T: Table> {
+    fn serialize<E: Error>(&self, b: PtrBuilder<'se, T>) -> Result<(), E>;
+}
+
+impl<'se, T, P> SerializePtr<'se, T> for Box<P>
+where
+    T: Table,
+    P: SerializePtr<'se, T>,
+{
+    #[inline]
+    fn serialize<E: Error>(&self, b: PtrBuilder<'se, T>) -> Result<(), E> {
+        <P as SerializePtr<'se, T>>::serialize(self, b)
+    }
+}
+
+impl<'se, T, P> SerializePtr<'se, T> for Option<P>
+where
+    T: Table,
+    P: SerializePtr<'se, T>,
+{
+    #[inline]
+    fn serialize<E: Error>(&self, b: PtrBuilder<'se, T>) -> Result<(), E> {
+        let Some(value) = self else { return Ok(()) };
+        value.serialize(b)
+    }
+}
+
+/// Invokes the given types `DeserializePtr` implementation.
+#[inline]
+pub fn deserialize<'de, T, E, P>(t: &PtrReader<'de, T>) -> Result<P, E>
+where
+    T: Table,
+    E: Error,
+    P: DeserializePtr<'de, T>,
+{
+    P::deserialize(t)
+}
+
+/// Invokes the given types `DeserializePtr` implementation.
+#[inline]
+pub fn serialize<'se, T, E, P>(value: &P, t: PtrBuilder<'se, T>) -> Result<(), E>
+where
+    T: Table,
+    E: Error,
+    P: SerializePtr<'se, T>,
+{
+    P::serialize(value, t)
+}
+
+/// Deserializes a struct directly from a pointer reader. If the pointer is null, it deserializes
+/// from an empty struct instead.
+#[inline]
+pub fn deserialize_struct<'de, T, E, S>(t: &PtrReader<'de, T>) -> Result<S, E>
+where
+    T: Table,
+    E: Error,
+    S: Deserialize<'de, T>,
+{
+    let r = match t.to_struct() {
+        Ok(Some(s)) => s,
+        Ok(None) => StructReader::empty().imbue_from(t),
+        Err(err) => return Err(E::protocol_error(err)),
+    };
+    S::deserialize(&r)
+}
+
+#[inline]
+pub fn serialize_struct<'se, T, E, S>(s: &S, b: PtrBuilder<'se, T>) -> Result<(), E>
+where
+    T: Table,
+    E: Error,
+    S: Serialize<'se, T>,
+{
+    match b.try_init_struct(S::SIZE) {
+        Ok(mut b) => s.serialize(&mut b),
+        Err((err, _)) => Err(E::protocol_error(err)),
+    }
+}
+
+pub trait DeserializeAnyPtrExt<'de, T: Table> {
+    fn deserialize<P, E>(&self) -> Result<P, E>
+    where
+        P: DeserializePtr<'de, T>,
+        E: Error;
+}
+
+impl<'de, T: Table> DeserializeAnyPtrExt<'de, T> for recapn::any::PtrReader<'de, T> {
+    fn deserialize<P, E>(&self) -> Result<P, E>
+    where
+        P: DeserializePtr<'de, T>,
+        E: Error,
+    {
+        P::deserialize(&self.as_ref())
+    }
+}
+
+pub trait SerializeAnyPtrExt<T: Table> {
+    fn serialize<P, E>(&mut self, value: &P) -> Result<(), E>
+    where
+        P: for<'se> SerializePtr<'se, T>,
+        E: Error;
+}
+
+impl<T: Table> SerializeAnyPtrExt<T> for recapn::any::PtrBuilder<'_, T> {
+    fn serialize<P, E>(&mut self, value: &P) -> Result<(), E>
+    where
+        P: for<'se> SerializePtr<'se, T>,
+        E: Error,
+    {
+        P::serialize(value, self.as_mut().by_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+}

--- a/recapn-port/src/list.rs
+++ b/recapn-port/src/list.rs
@@ -1,0 +1,305 @@
+use core::ops::{Deref, DerefMut};
+
+use recapn::ptr::{ElementSize, PtrBuilder, PtrElementSize, PtrReader};
+use recapn::rpc::Table;
+use recapn::ty;
+
+use crate::data::Data;
+use crate::text::Text;
+use crate::{Deserialize, DeserializePtr, Enum, Error, Serialize, SerializePtr};
+
+pub struct List<T>(pub Vec<T>);
+
+impl<T> Deref for List<T> {
+    type Target = Vec<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for List<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<Vec<T>> for List<T> {
+    #[inline]
+    fn from(value: Vec<T>) -> Self {
+        List(value)
+    }
+}
+
+impl<T> From<List<T>> for Vec<T> {
+    #[inline]
+    fn from(value: List<T>) -> Self {
+        value.0
+    }
+}
+
+pub trait DeserializeList<'de, T: Table>: Sized {
+    fn deserialize<E: Error>(r: &PtrReader<'de, T>) -> Result<List<Self>, E>;
+}
+
+macro_rules! deserialize_list_ptr {
+    ($ptr:expr, $size:expr, |$list:pat_param| $block:block) => {
+        match $ptr.to_list($size) {
+            Ok(Some($list)) => $block,
+            Ok(None) => Ok(List(Vec::new())),
+            Err(err) => Err(E::protocol_error(err)),
+        }
+    };
+}
+
+macro_rules! deserialize_list {
+    ($ty:ty, $size:expr, |$list:pat_param| $block:block) => {
+        impl<T: Table> DeserializeList<'_, T> for $ty {
+            fn deserialize<E: Error>(r: &PtrReader<'_, T>) -> Result<List<Self>, E> {
+                deserialize_list_ptr!(r, $size, |$list| $block)
+            }
+        }
+    };
+}
+
+macro_rules! deserialize_data_list {
+    ($ty:ty, $size:expr) => {
+        deserialize_list!($ty, Some($size), |l| {
+            let len = l.len().get();
+            let mut v = Vec::with_capacity(len as usize);
+            for i in 0..len {
+                v.push(unsafe { l.data_unchecked(i) });
+            }
+            Ok(List(v))
+        });
+    };
+}
+
+deserialize_list!((), Some(PtrElementSize::Void), |l| {
+    Ok(List(vec![(); l.len().get() as usize]))
+});
+
+deserialize_data_list!(bool, PtrElementSize::Bit);
+
+deserialize_data_list!(u8, PtrElementSize::Byte);
+deserialize_data_list!(i8, PtrElementSize::Byte);
+
+deserialize_data_list!(u16, PtrElementSize::TwoBytes);
+deserialize_data_list!(i16, PtrElementSize::TwoBytes);
+
+deserialize_data_list!(u32, PtrElementSize::FourBytes);
+deserialize_data_list!(i32, PtrElementSize::FourBytes);
+deserialize_data_list!(f32, PtrElementSize::FourBytes);
+
+deserialize_data_list!(u64, PtrElementSize::EightBytes);
+deserialize_data_list!(i64, PtrElementSize::EightBytes);
+deserialize_data_list!(f64, PtrElementSize::EightBytes);
+
+impl<En: ty::Enum, T: Table> DeserializeList<'_, T> for Enum<En> {
+    fn deserialize<E: Error>(r: &PtrReader<'_, T>) -> Result<List<Self>, E> {
+        deserialize_list_ptr!(r, Some(PtrElementSize::TwoBytes), |l| {
+            let len = l.len().get();
+            let mut v = Vec::with_capacity(len as usize);
+            for i in 0..len {
+                v.push(Enum::from_value(unsafe { l.data_unchecked::<u16>(i) }));
+            }
+            Ok(List(v))
+        })
+    }
+}
+
+deserialize_list!(Text, Some(PtrElementSize::Pointer), |l| {
+    let len = l.len().get();
+    let mut v = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let ptr = unsafe { l.ptr_unchecked(i) };
+        v.push(<Text as DeserializePtr<'_, _>>::deserialize(&ptr)?);
+    }
+    Ok(List(v))
+});
+
+deserialize_list!(Data, Some(PtrElementSize::Pointer), |l| {
+    let len = l.len().get();
+    let mut v = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let ptr = unsafe { l.ptr_unchecked(i) };
+        v.push(<Data as DeserializePtr<'_, _>>::deserialize(&ptr)?);
+    }
+    Ok(List(v))
+});
+
+impl<'de, V, T> DeserializeList<'de, T> for List<V>
+where
+    V: DeserializeList<'de, T>,
+    T: Table,
+{
+    fn deserialize<E: Error>(r: &PtrReader<'de, T>) -> Result<List<Self>, E> {
+        deserialize_list_ptr!(r, Some(PtrElementSize::Pointer), |l| {
+            let len = l.len().get();
+            let mut v = Vec::with_capacity(len as usize);
+            for i in 0..len {
+                let ptr = unsafe { l.ptr_unchecked(i) };
+                v.push(<V as DeserializeList<'de, T>>::deserialize(&ptr)?.into());
+            }
+            Ok(List(v))
+        })
+    }
+}
+
+#[inline]
+pub fn deserialize_struct_list<'de, S, T, E>(r: &PtrReader<'de, T>) -> Result<List<S>, E>
+where
+    S: Deserialize<'de, T>,
+    T: Table,
+    E: Error,
+{
+    deserialize_list_ptr!(r, Some(PtrElementSize::InlineComposite), |l| {
+        let len = l.len().get();
+        let mut v = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let s = unsafe { l.struct_unchecked(i) };
+            v.push(<S as Deserialize<'de, T>>::deserialize(&s)?);
+        }
+        Ok(List(v))
+    })
+}
+
+pub trait SerializeList<'se, T: Table>: Sized {
+    fn serialize<E: Error>(s: &[Self], b: PtrBuilder<'se, T>) -> Result<(), E>;
+}
+
+macro_rules! serialize_list_ptr {
+    ($slice:expr, $ptr:expr, $size:expr, |$slice_pat:pat_param, $list:pat_param| $block:block) => {
+        'm: {
+            let slice = $slice;
+            let Ok(len) = recapn::ptr::ElementCount::try_from(slice.len()) else {
+                break 'm Err(E::protocol_error(recapn::Error::AllocTooLarge))
+            };
+            let $slice_pat = slice;
+            match $ptr.try_init_list($size, len) {
+                Ok($list) => $block,
+                Err((err, _)) => Err(E::protocol_error(err)),
+            }
+        }
+    };
+}
+
+macro_rules! serialize_list {
+    ($ty:ty, $size:expr, |$slice:pat_param, $list:pat_param| $block:block) => {
+        impl<T: Table> SerializeList<'_, T> for $ty {
+            fn serialize<E: Error>(s: &[Self], b: PtrBuilder<'_, T>) -> Result<(), E> {
+                serialize_list_ptr!(s, b, $size, |$slice, $list| $block)
+            }
+        }
+    };
+}
+
+macro_rules! serialize_data_list {
+    ($ty:ty, $size:expr) => {
+        serialize_list!($ty, $size, |slice, mut l| {
+            for (i, &value) in slice.iter().enumerate() {
+                unsafe { l.set_data_unchecked(i as u32, value) }
+            }
+            Ok(())
+        });
+    };
+}
+
+serialize_list!((), ElementSize::Void, |_, _| { Ok(()) });
+
+serialize_data_list!(bool, ElementSize::Bit);
+
+serialize_data_list!(u8, ElementSize::Byte);
+serialize_data_list!(i8, ElementSize::Byte);
+
+serialize_data_list!(u16, ElementSize::TwoBytes);
+serialize_data_list!(i16, ElementSize::TwoBytes);
+
+serialize_data_list!(u32, ElementSize::FourBytes);
+serialize_data_list!(i32, ElementSize::FourBytes);
+serialize_data_list!(f32, ElementSize::FourBytes);
+
+serialize_data_list!(u64, ElementSize::EightBytes);
+serialize_data_list!(i64, ElementSize::EightBytes);
+serialize_data_list!(f64, ElementSize::EightBytes);
+
+impl<En: ty::Enum, T: Table> SerializeList<'_, T> for Enum<En> {
+    fn serialize<E: Error>(s: &[Self], b: PtrBuilder<'_, T>) -> Result<(), E> {
+        serialize_list_ptr!(s, b, ElementSize::TwoBytes, |s, mut l| {
+            for (i, &value) in s.iter().enumerate() {
+                unsafe { l.set_data_unchecked(i as u32, value.into_value()) }
+            }
+            Ok(())
+        })
+    }
+}
+
+serialize_list!(Text, ElementSize::Pointer, |s, mut l| {
+    for (i, value) in s.iter().enumerate() {
+        let ptr = unsafe { l.ptr_mut_unchecked(i as u32) };
+        <Text as SerializePtr<'_, _>>::serialize(value, ptr)?
+    }
+    Ok(())
+});
+
+serialize_list!(Data, ElementSize::Pointer, |s, mut l| {
+    for (i, value) in s.iter().enumerate() {
+        let ptr = unsafe { l.ptr_mut_unchecked(i as u32) };
+        <Data as SerializePtr<'_, _>>::serialize(value, ptr)?
+    }
+    Ok(())
+});
+
+impl<'se, V, T> SerializeList<'se, T> for List<V>
+where
+    V: for<'se2> SerializeList<'se2, T>,
+    T: Table,
+{
+    fn serialize<E: Error>(s: &[Self], b: PtrBuilder<'se, T>) -> Result<(), E> {
+        serialize_list_ptr!(s, b, ElementSize::Pointer, |s, mut l| {
+            for (i, value) in s.iter().enumerate() {
+                let ptr = unsafe { l.ptr_mut_unchecked(i as u32) };
+                <V as SerializeList<'_, _>>::serialize(value, ptr)?;
+            }
+            Ok(())
+        })
+    }
+}
+
+#[inline]
+pub fn serialize_struct_list<S, T, E>(s: &[S], b: PtrBuilder<'_, T>) -> Result<(), E>
+where
+    S: for<'se> Serialize<'se, T>,
+    T: Table,
+    E: Error,
+{
+    serialize_list_ptr!(s, b, ElementSize::InlineComposite(S::SIZE), |s, mut l| {
+        for (i, src) in s.iter().enumerate() {
+            let mut dst = unsafe { l.struct_mut_unchecked(i as u32) };
+            src.serialize(&mut dst)?;
+        }
+        Ok(())
+    })
+}
+
+impl<'de, T, V> DeserializePtr<'de, T> for List<V>
+where
+    T: Table,
+    V: DeserializeList<'de, T>,
+{
+    fn deserialize<E: Error>(r: &PtrReader<'de, T>) -> Result<Self, E> {
+        <V as DeserializeList<'de, T>>::deserialize(r)
+    }
+}
+
+impl<'se, T, V> SerializePtr<'se, T> for List<V>
+where
+    T: Table,
+    V: SerializeList<'se, T>,
+{
+    fn serialize<E: Error>(&self, b: PtrBuilder<'se, T>) -> Result<(), E> {
+        <V as SerializeList<'se, T>>::serialize(self, b)
+    }
+}

--- a/recapn-port/src/text.rs
+++ b/recapn-port/src/text.rs
@@ -1,0 +1,184 @@
+use core::fmt;
+
+use recapn::{ptr::PtrReader, rpc::Table};
+
+use crate::{DeserializePtr, Error, SerializePtr};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TextFromBytesError(());
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum TextFromBytesWithNulError {
+    TextTooLarge,
+    MissingNul,
+}
+
+#[derive(Clone)]
+pub struct Text {
+    // Invariant 1: the slice ends with a zero byte and has a length of at least one.
+    // Invariant 2: the slice is within the max size of Cap'n Proto text.
+    inner: Box<[u8]>,
+}
+
+impl fmt::Debug for Text {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes = self.to_bytes();
+
+        // Copied from core::bstr
+        write!(f, "\"")?;
+        for chunk in bytes.utf8_chunks() {
+            for c in chunk.valid().chars() {
+                match c {
+                    '\0' => write!(f, "\\0")?,
+                    '\x01'..='\x7f' => write!(f, "{}", (c as u8).escape_ascii())?,
+                    _ => write!(f, "{}", c.escape_debug())?,
+                }
+            }
+            write!(f, "{}", chunk.invalid().escape_ascii())?;
+        }
+        write!(f, "\"")?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for Text {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes = self.to_bytes();
+
+        fn fmt_nopad(this: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            for chunk in this.utf8_chunks() {
+                f.write_str(chunk.valid())?;
+                if !chunk.invalid().is_empty() {
+                    f.write_str("\u{FFFD}")?;
+                }
+            }
+            Ok(())
+        }
+
+        let Some(align) = f.align() else {
+            return fmt_nopad(bytes, f);
+        };
+        let nchars: usize = bytes
+            .utf8_chunks()
+            .map(|chunk| {
+                chunk.valid().chars().count() + if chunk.invalid().is_empty() { 0 } else { 1 }
+            })
+            .sum();
+        let padding = f.width().unwrap_or(0).saturating_sub(nchars);
+        let fill = f.fill();
+        let (lpad, rpad) = match align {
+            fmt::Alignment::Left => (0, padding),
+            fmt::Alignment::Right => (padding, 0),
+            fmt::Alignment::Center => {
+                let half = padding / 2;
+                (half, half + padding % 2)
+            }
+        };
+        for _ in 0..lpad {
+            write!(f, "{fill}")?;
+        }
+        fmt_nopad(bytes, f)?;
+        for _ in 0..rpad {
+            write!(f, "{fill}")?;
+        }
+
+        Ok(())
+
+    }
+
+}
+
+impl Text {
+    pub fn try_from_bytes(b: &[u8]) -> Result<Self, TextFromBytesError> {
+        let len = b.len() + 1; // add 1 for the null terminator
+        if recapn::ptr::ElementCount::try_from(len).is_err() {
+            return Err(TextFromBytesError(()))
+        }
+        let mut vec = Vec::with_capacity(len);
+        vec.extend_from_slice(b);
+        vec.push(0);
+        Ok(Self { inner: vec.into_boxed_slice() })
+    }
+    #[inline]
+    pub fn from_bytes(b: &[u8]) -> Self {
+        Self::try_from_bytes(b).unwrap()
+    }
+
+    #[inline]
+    pub fn try_new(b: impl AsRef<[u8]>) -> Result<Self, TextFromBytesError> {
+        Self::try_from_bytes(b.as_ref())
+    }
+    #[inline]
+    pub fn new(b: impl AsRef<[u8]>) -> Self {
+        Self::from_bytes(b.as_ref())
+    }
+
+    pub fn try_from_bytes_with_nul(b: &[u8]) -> Result<Self, TextFromBytesWithNulError> {
+        let Some(0) = b.last() else { return Err(TextFromBytesWithNulError::MissingNul) };
+        let len = b.len();
+        if recapn::ptr::ElementCount::try_from(len).is_err() {
+            return Err(TextFromBytesWithNulError::TextTooLarge)
+        }
+        let mut vec = Vec::with_capacity(len);
+        vec.extend_from_slice(b);
+        vec.push(0);
+        Ok(Self { inner: vec.into_boxed_slice() })
+    }
+    #[inline]
+    pub fn from_bytes_with_nul(b: &[u8]) -> Self {
+        Self::try_from_bytes_with_nul(b).unwrap()
+    }
+
+    #[inline]
+    pub fn from_reader(r: recapn::text::Reader<'_>) -> Self {
+        Self { inner: Box::from(r.as_bytes_with_nul()) }
+    }
+
+    #[inline]
+    pub fn to_bytes(&self) -> &[u8] {
+        match self.to_bytes_with_nul() {
+            [r @ .., _] => r,
+            r => {
+                if cfg!(debug_assertions) {
+                    unreachable!("Text slice must contain at least one element")
+                }
+                r
+            },
+        }
+    }
+    #[inline]
+    pub fn to_bytes_with_nul(&self) -> &[u8] {
+        &self.inner
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.to_bytes().is_empty()
+    }
+}
+
+impl<T: Table> DeserializePtr<'_, T> for Text {
+    fn deserialize<E: Error>(r: &PtrReader<'_, T>) -> Result<Self, E> {
+        let text = match r.to_blob() {
+            Ok(Some(b)) => match recapn::text::Reader::new(b) {
+                Some(text) => text,
+                None => return Err(E::protocol_error(recapn::Error::TextNotNulTerminated)),
+            },
+            Ok(None) => recapn::text::Reader::empty(),
+            Err(err) => return Err(E::protocol_error(err)),
+        };
+        Ok(Self::from_reader(text))
+    }
+}
+
+impl<T: Table> SerializePtr<'_, T> for Text {
+    fn serialize<E: Error>(&self, b: recapn::ptr::PtrBuilder<'_, T>) -> Result<(), E> {
+        let len = self.inner.len().try_into().unwrap();
+        let mut blob = match b.try_init_blob(len) {
+            Ok(blob) => recapn::data::Builder::from(blob),
+            Err((err, _)) => return Err(E::protocol_error(err)),
+        };
+        blob.copy_from_slice(&self.inner);
+        Ok(())
+    }
+}

--- a/recapn/src/alloc.rs
+++ b/recapn/src/alloc.rs
@@ -425,12 +425,17 @@ impl<const N: usize> Space<N> {
     }
 
     #[inline]
-    pub(crate) fn segment(&mut self) -> Segment {
+    pub(crate) fn use_scratch(&mut self) -> Segment {
         if self.dirty {
             self.space.fill(Word::NULL);
         }
 
         self.dirty = true;
+        self.segment()
+    }
+
+    #[inline]
+    fn segment(&mut self) -> Segment {
         let len = AllocLen::new(N as u32).unwrap().into();
         let data = NonNull::new(self.space.as_mut_ptr()).unwrap();
 
@@ -475,12 +480,17 @@ impl DynSpace {
     }
 
     #[inline]
-    pub(crate) fn segment(&mut self) -> Segment {
+    pub(crate) fn use_scratch(&mut self) -> Segment {
         if self.dirty {
             self.space.fill(Word::NULL);
         }
 
         self.dirty = true;
+        self.segment()
+    }
+
+    #[inline]
+    fn segment(&mut self) -> Segment {
         let len = AllocLen::new(self.space.len() as u32).unwrap().into();
         let data = NonNull::new(self.space.as_mut_ptr()).unwrap();
 
@@ -504,7 +514,7 @@ impl<'s, A> Scratch<'s, A> {
     pub fn with_space<const N: usize>(space: &'s mut Space<N>, alloc: A) -> Self {
         Self {
             s: PhantomData,
-            segment: space.segment(),
+            segment: space.use_scratch(),
             used: false,
             next: alloc,
         }
@@ -516,7 +526,7 @@ impl<'s, A> Scratch<'s, A> {
     pub fn with_dyn_space(space: &'s mut DynSpace, alloc: A) -> Self {
         Self {
             s: PhantomData,
-            segment: space.segment(),
+            segment: space.use_scratch(),
             used: false,
             next: alloc,
         }

--- a/recapn/src/lib.rs
+++ b/recapn/src/lib.rs
@@ -74,6 +74,9 @@ pub mod prelude {
     }
 }
 
+#[cfg(feature = "alloc")]
+pub use ty::deep_clone;
+
 /// A marker type used in place of a concrete generic implementation for a message's representation.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Family;

--- a/recapn/src/message.rs
+++ b/recapn/src/message.rs
@@ -21,14 +21,42 @@ struct SingleSegmentArena {
 }
 
 impl SingleSegmentArena {
+    #[inline]
     fn new(segment: Segment) -> Self {
         Self {
             segment: UnsafeCell::new(unsafe { ArenaSegment::new(segment, AllocLen::ONE, 0) }),
         }
     }
 
+    #[inline]
     fn segment(&self) -> &ArenaSegment {
         unsafe { &*self.segment.get() }
+    }
+
+    #[inline]
+    fn replace_segment(&mut self, segment: Segment) -> Segment {
+        core::mem::replace(
+            self.segment.get_mut(),
+            unsafe { ArenaSegment::new(segment, AllocLen::ONE, 0) }
+        ).segment()
+    }
+
+    fn replace_and_copy_segment(&mut self, mut new_segment: Segment) -> Segment {
+        let segment = self.segment.get_mut();
+        let old_segment = segment.segment();
+        assert!(old_segment.len < new_segment.len);
+
+        let len = AllocLen::new_unwrap(segment.used_len().get());
+        let len_usize = len.get() as usize;
+        let new_slice;
+        let old_slice;
+        unsafe {
+            new_slice = &mut new_segment.as_mut_bytes_unchecked()[..len_usize];
+            old_slice = &old_segment.as_bytes_unchecked()[..len_usize];
+        }
+        new_slice.copy_from_slice(old_slice);
+        *segment = unsafe { ArenaSegment::new(new_segment, len, 0) };
+        old_segment
     }
 }
 
@@ -75,26 +103,34 @@ unsafe impl ReadArena for SingleSegmentArena {
     }
 }
 
-/// A fixed sized message that can write to one segment.
-pub struct SingleSegmentMessage<'a> {
+/// A fixed size message that can only write to one segment provided by scratch space.
+pub struct ScratchMessage<'a> {
     a: PhantomData<&'a mut [Word]>,
     arena: SingleSegmentArena,
 }
 
-impl<'a> SingleSegmentMessage<'a> {
+impl<'a> ScratchMessage<'a> {
+    #[inline]
     pub fn with_space<const N: usize>(space: &'a mut Space<N>) -> Self {
         Self {
             a: PhantomData,
-            arena: SingleSegmentArena::new(space.segment()),
+            arena: SingleSegmentArena::new(space.use_scratch()),
         }
     }
 
     #[cfg(feature = "alloc")]
+    #[inline]
     pub fn with_dyn_space(space: &'a mut DynSpace) -> Self {
         Self {
             a: PhantomData,
-            arena: SingleSegmentArena::new(space.segment()),
+            arena: SingleSegmentArena::new(space.use_scratch()),
         }
+    }
+
+    /// Return the message's internal arena as a `ReadArena` trait object reference.
+    #[inline]
+    pub fn as_read_arena(&self) -> &dyn ReadArena {
+        &self.arena
     }
 
     /// Creates a new reader for this message. This reader has no limits placed on it.
@@ -122,21 +158,153 @@ impl<'a> SingleSegmentMessage<'a> {
     }
 
     /// Return the used space of the message as a slice of [`Word`]s.
+    #[inline]
     pub fn as_words(&self) -> &[Word] {
         unsafe { self.arena.segment().used_segment().as_slice_unchecked() }
     }
 
     /// Return the used space of the message as a slice of bytes.
+    #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         Word::slice_to_bytes(self.as_words())
+    }
+
+    #[inline]
+    pub fn free_words(&self) -> u32 {
+        let segment = self.arena.segment();
+        let original = segment.segment().len.get();
+        let used = segment.used_len().get();
+        original - used
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.free_words() == 0
     }
 }
 
 // These are safe since, even though this type has interior mutability, we don't expose any of
 // it from this level of the API. So a user can pass instances of this type between threads
 // as much as they want (though they probably won't).
-unsafe impl Send for SingleSegmentMessage<'_> {}
-unsafe impl Sync for SingleSegmentMessage<'_> {}
+unsafe impl Send for ScratchMessage<'_> {}
+unsafe impl Sync for ScratchMessage<'_> {}
+
+/// A fixed sized message that can only write to one segment allocated by the given allocator.
+/// 
+/// Allocators are not guaranteed to allocate the length provided, so if that behavior is required,
+/// make sure to use an allocator that does have that behavior.
+pub struct SingleSegmentMessage<A: Alloc + ?Sized> {
+    arena: SingleSegmentArena,
+    alloc: A,
+}
+
+impl<A: Alloc> SingleSegmentMessage<A> {
+    pub fn new(mut alloc: A, init_len: AllocLen) -> Option<Self> {
+        Some(Self {
+            arena: unsafe { SingleSegmentArena::new(alloc.alloc(init_len)?) },
+            alloc,
+        })
+    }
+}
+
+impl<A: Alloc + ?Sized> SingleSegmentMessage<A> {
+    /// Increases the size of the message, reallocating the segment and copying data if necessary.
+    /// 
+    /// If the existing segment is larger than the given length, this returns true.
+    /// 
+    /// Note: to prevent the message from being in a bad state on allocation failure, the new
+    /// segment is allocated *before* deallocating the old one.
+    pub fn grow(&mut self, new_len: AllocLen) -> bool {
+        if self.arena.segment.get_mut().segment().len >= new_len {
+            return true
+        }
+
+        let Some(new_segment) = (unsafe { self.alloc.alloc(new_len) }) else { return false };
+        let old = self.arena.replace_and_copy_segment(new_segment);
+        unsafe {
+            self.alloc.dealloc(old);
+        }
+        true
+    }
+
+    /// Replace the segment with a new one, clearing the message and allocating a new segment with
+    /// the allocator.
+    /// 
+    /// Note: to prevent the message from being in a bad state on allocation failure, the new
+    /// segment is allocated *before* deallocating the old one.
+    pub fn replace(&mut self, new_len: AllocLen) -> bool {
+        let Some(new) = (unsafe { self.alloc.alloc(new_len) }) else { return false };
+        let old = self.arena.replace_segment(new);
+        unsafe {
+            self.alloc.dealloc(old);
+        }
+        true
+    }
+
+    /// Return the message's internal arena as a `ReadArena` trait object reference.
+    #[inline]
+    pub fn as_read_arena(&self) -> &dyn ReadArena {
+        &self.arena
+    }
+
+    /// Creates a new reader for this message. This reader has no limits placed on it.
+    ///
+    /// If you want a limited reader, use [`Message::reader_with_options`].
+    #[inline]
+    pub fn reader(&self) -> Reader<'_> {
+        Reader::limitless(&self.arena)
+    }
+
+    /// Creates a new reader for this message with the specified reader options.
+    #[inline]
+    pub fn reader_with_options(&self, options: ReaderOptions) -> Reader<'_> {
+        Reader::new(&self.arena, options)
+    }
+
+    /// Gets the builder for this message.
+    #[inline]
+    pub fn builder(&mut self) -> Builder<'_, 'static> {
+        Builder {
+            e: PhantomData,
+            root: self.arena.segment(),
+            arena: &self.arena,
+        }
+    }
+
+    /// Return the used space of the message as a slice of [`Word`]s.
+    #[inline]
+    pub fn as_words(&self) -> &[Word] {
+        unsafe { self.arena.segment().used_segment().as_slice_unchecked() }
+    }
+
+    /// Return the used space of the message as a slice of bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        Word::slice_to_bytes(self.as_words())
+    }
+
+    #[inline]
+    pub fn free_words(&self) -> u32 {
+        let segment = self.arena.segment();
+        let original = segment.segment().len.get();
+        let used = segment.used_len().get();
+        original - used
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.free_words() == 0
+    }
+}
+
+impl<T: Alloc + ?Sized> Drop for SingleSegmentMessage<T> {
+    fn drop(&mut self) {
+        unsafe { self.alloc.dealloc(self.arena.segment.get_mut().segment()) }
+    }
+}
+
+unsafe impl<T: Alloc + Send + ?Sized> Send for SingleSegmentMessage<T> {}
+unsafe impl<T: Alloc + ?Sized> Sync for SingleSegmentMessage<T> {}
 
 /// A message. Can be used to create multiple readers or one builder at a time.
 ///

--- a/recapn/src/message.rs
+++ b/recapn/src/message.rs
@@ -453,7 +453,7 @@ impl Default for ReaderOptions {
 }
 
 /// Controls how far a single message reader can read into a message.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReadLimiter {
     limit: Cell<u64>,
 }

--- a/recapn/src/ptr.rs
+++ b/recapn/src/ptr.rs
@@ -221,6 +221,35 @@ impl core::ops::AddAssign for MessageSize {
     }
 }
 
+impl MessageSize {
+    #[inline]
+    pub fn has_caps(&self) -> bool {
+        self.caps != 0
+    }
+
+    /// Get the `AllocLen` of this message size, if it fits within a single capnp allocation,
+    /// without accounting for the root pointer.
+    #[inline]
+    pub fn alloc_words(&self) -> Option<AllocLen> {
+        if self.words > AllocLen::MAX_VALUE as u64 {
+            return None
+        }
+
+        AllocLen::new(self.words as u32)
+    }
+
+    /// Get the `AllocLen` of this message size, if it fits within a single capnp allocation,
+    /// including a root pointer.
+    #[inline]
+    pub fn alloc_words_with_root(&self) -> Option<AllocLen> {
+        if self.words >= AllocLen::MAX_VALUE as u64 {
+            return None
+        }
+
+        AllocLen::new(self.words as u32 + 1)
+    }
+}
+
 /// The size of a struct in data words and pointers.
 ///
 /// A struct in Cap'n Proto is made up of a "data" section and a pointer section. Space in each

--- a/recapn/src/ptr.rs
+++ b/recapn/src/ptr.rs
@@ -1629,6 +1629,19 @@ pub(crate) struct ObjectReader<'a> {
 
 impl<'a> ObjectReader<'a> {
     #[inline]
+    pub fn clone_limiter(&self) -> Option<ReadLimiter> {
+        self.limiter.cloned()
+    }
+
+    #[inline]
+    pub fn with_limiter<'b>(&self, limiter: Option<&'b ReadLimiter>) -> ObjectReader<'b>
+    where
+        'a: 'b
+    {
+        ObjectReader { segment: self.segment.clone(), limiter }
+    }
+
+    #[inline]
     pub unsafe fn section_slice(&self, ptr: SegmentRef<'a>, len: SegmentOffset) -> &[Word] {
         if let Some(segment) = &self.segment {
             debug_assert!(segment.try_get_section(ptr.into(), len).is_some());
@@ -2204,7 +2217,10 @@ impl<'a, T: Table> PtrReader<'a, T> {
             .checked_sub(1)
             .ok_or(Error::NestingLimitExceeded)?;
 
-        target_size(&self.reader, self.ptr, nesting_limit)
+        let limiter = self.reader.clone_limiter();
+        let reader = self.reader.with_limiter(limiter.as_ref());
+
+        target_size(&reader, self.ptr, nesting_limit)
     }
 
     #[inline]
@@ -2213,7 +2229,8 @@ impl<'a, T: Table> PtrReader<'a, T> {
             return Ok(PtrType::Null);
         }
 
-        let mut reader = self.reader.clone();
+        let limiter = self.reader.clone_limiter();
+        let mut reader = self.reader.with_limiter(limiter.as_ref());
         let Content { ptr, .. } = reader.location_of(self.ptr)?;
         if ptr.is_struct() {
             Ok(PtrType::Struct)
@@ -2228,7 +2245,11 @@ impl<'a, T: Table> PtrReader<'a, T> {
 
     #[inline]
     pub fn equality<T2: Table>(&self, other: &PtrReader<'_, T2>) -> Result<PtrEquality> {
-        cmp_ptr(self.ptr, &self.reader, other.ptr, &other.reader)
+        let self_limiter = self.reader.clone_limiter();
+        let self_reader = self.reader.with_limiter(self_limiter.as_ref());
+        let other_limiter = other.reader.clone_limiter();
+        let other_reader = other.reader.with_limiter(other_limiter.as_ref());
+        cmp_ptr(self.ptr, &self_reader, other.ptr, &other_reader)
     }
 
     #[inline]
@@ -2531,8 +2552,10 @@ impl<'a, T: Table> StructReader<'a, T> {
             caps: 0,
         };
 
+        let limiter = self.reader.clone_limiter();
+        let reader = self.reader.with_limiter(limiter.as_ref());
         let ptrs_targets_size = total_ptrs_size(
-            &self.reader,
+            &reader,
             self.ptrs_start,
             self.ptrs_len.into(),
             self.nesting_limit,
@@ -2549,13 +2572,17 @@ impl<'a, T: Table> StructReader<'a, T> {
             return Ok(PtrEquality::NotEqual);
         }
 
+        let self_limiter = self.reader.clone_limiter();
+        let self_reader = self.reader.with_limiter(self_limiter.as_ref());
+        let other_limiter = other.reader.clone_limiter();
+        let other_reader = other.reader.with_limiter(other_limiter.as_ref());
         cmp_ptr_sections(
             self.ptrs_start,
             self.ptrs_len.into(),
-            &self.reader,
+            &self_reader,
             other.ptrs_start,
             other.ptrs_len.into(),
-            &other.reader,
+            &other_reader,
         )
     }
 
@@ -2813,16 +2840,18 @@ impl<'a, T: Table> ListReader<'a, T> {
             caps: 0,
         };
 
+        let limiter = self.reader.clone_limiter();
+        let reader = self.reader.with_limiter(limiter.as_ref());
         match self.element_size {
             ElementSize::Pointer => {
                 let target_sizes =
-                    total_ptrs_size(&self.reader, self.ptr, len, self.nesting_limit)?;
+                    total_ptrs_size(&reader, self.ptr, len, self.nesting_limit)?;
 
                 Ok(list_size + target_sizes)
             }
             ElementSize::InlineComposite(size) => {
                 let target_sizes = total_inline_composites_targets_size(
-                    &self.reader,
+                    &reader,
                     self.ptr,
                     len,
                     size,
@@ -2837,19 +2866,23 @@ impl<'a, T: Table> ListReader<'a, T> {
 
     #[inline]
     pub fn equality<T2: Table>(&self, other: &ListReader<'_, T2>) -> Result<PtrEquality> {
+        let self_limiter = self.reader.clone_limiter();
+        let self_reader = self.reader.with_limiter(self_limiter.as_ref());
+        let other_limiter = other.reader.clone_limiter();
+        let other_reader = other.reader.with_limiter(other_limiter.as_ref());
         cmp_list(
             &ListContent {
                 ptr: self.ptr,
                 element_size: self.element_size,
                 element_count: self.element_count,
             },
-            &self.reader,
+            &self_reader,
             &ListContent {
                 ptr: other.ptr,
                 element_size: other.element_size,
                 element_count: other.element_count,
             },
-            &other.reader,
+            &other_reader,
         )
     }
 

--- a/recapn/src/ty.rs
+++ b/recapn/src/ty.rs
@@ -4,15 +4,15 @@ use core::convert::TryFrom;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 
-use crate::alloc::Word;
-use crate::any::{self, PtrReader};
+use crate::alloc::{Word, Global};
+use crate::any;
 use crate::field;
 use crate::internal::Sealed;
 use crate::list::{self, ElementSize, List};
-use crate::ptr::{self, MessageSize, StructSize};
+use crate::message::SingleSegmentMessage;
+use crate::ptr::{self, MessageSize, StructSize, ReturnErrors};
 use crate::rpc::{Capable, Table};
-use crate::ReaderOf;
-use crate::{IntoFamily, NotInSchema, Result};
+use crate::{Error, IntoFamily, NotInSchema, ReaderOf, Result};
 
 /// An enum marker trait.
 pub trait Enum: Copy + TryFrom<u16, Error = NotInSchema> + Into<u16> + Default + 'static {}
@@ -261,7 +261,7 @@ impl<T> ConstPtr<T> {
 
     /// Get the value of the constant as an untyped pointer.
     #[inline]
-    pub fn root(&self) -> PtrReader<'static> {
+    pub fn root(&self) -> any::PtrReader<'static> {
         let ptr = match self.inner {
             Some(ptr) => unsafe { ptr::PtrReader::new_unchecked(ptr) },
             None => ptr::PtrReader::null(),
@@ -270,12 +270,70 @@ impl<T> ConstPtr<T> {
     }
 }
 
-impl<T: FromPtr<PtrReader<'static>>> ConstPtr<T> {
+impl<T: FromPtr<any::PtrReader<'static>>> ConstPtr<T> {
     /// Get the value of the constant.
     #[inline]
     pub fn get(&self) -> T::Output {
         self.root().read_as::<T>()
     }
+}
+
+#[cfg(feature = "alloc")]
+pub struct DeepClone<S> {
+    s: PhantomData<fn() -> S>,
+    message: SingleSegmentMessage<Global>,
+}
+
+#[cfg(feature = "alloc")]
+impl<S: StructView> DeepClone<S> {
+    #[inline]
+    pub fn new(s: &ReaderOf<'_, S>) -> Result<Self> {
+        Self::from_ptr(s.as_ref())
+    }
+
+    fn from_ptr(s: &ptr::StructReader<'_>) -> Result<Self> {
+        let size = s.total_size()?;
+        if size.has_caps() {
+            return Err(Error::CapabilityNotAllowed);
+        }
+
+        let Some(len) = size.alloc_words_with_root() else {
+            return Err(Error::AllocTooLarge);
+        };
+
+        let mut message = SingleSegmentMessage::new(Global, len).unwrap();
+        let result = message.builder()
+            .into_root()
+            .as_mut()
+            .try_set_struct(s, ptr::CopySize::FromValue, ReturnErrors);
+
+        match result {
+            Err(Error::AllocFailed(_)) => unreachable!(),
+            r => r?,
+        }
+
+        assert!(message.is_full());
+
+        Ok(Self { s: PhantomData, message })
+    }
+
+    #[inline]
+    pub fn get(&self) -> ReaderOf<'_, S> {
+        let ptr = ptr::PtrReader::root(self.message.as_read_arena(), None, u32::MAX)
+            .expect("the message has a root pointer");
+        let reader = match ptr.to_struct() {
+            Ok(Some(ptr)) => ptr,
+            _ => ptr::StructReader::empty(),
+        };
+        StructReader::from_ptr(reader)
+    }
+}
+
+/// Create a deep clone of the given struct.
+#[inline]
+#[cfg(feature = "alloc")]
+pub fn deep_clone<S: StructView>(s: &ReaderOf<'_, S>) -> Result<DeepClone<S>> {
+    DeepClone::new(s)
 }
 
 pub type Void = ();

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 recapn = { path = "../recapn" }
 recapn-rpc = { path = "../recapn-rpc" }
+recapn-port = { path = "../recapn-port" }
 tokio = { version = "1.35", default-features = false, features = ["full"] }
 
 [build-dependencies]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,6 +3,9 @@
 #[rustfmt::skip]
 pub mod generated;
 
+#[rustfmt::skip]
+pub mod ports;
+
 pub mod build_gen {
     include!(concat!(env!("OUT_DIR"), "/build_rs/mod.rs"));
 }
@@ -12,6 +15,7 @@ use std::time::Instant;
 use generated::capnp_test_capnp::{TestAllTypes, TestEnum};
 use recapn::message::Message;
 use recapn::{text, ty};
+use recapn_port::{DeserializeAnyPtrExt, DeserializePtr, SerializeAnyPtrExt, SerializePtr};
 use recapn_rpc::client::{Client, Request};
 use recapn_rpc::server::{
     CallContext, CallResult, Dispatch, DispatchRequest, DispatchResponse, Dispatcher, FromServer,
@@ -39,6 +43,46 @@ fn make_all_types() {
     inner.float32_field().set(32.32);
     inner.float64_field().set(64.64);
     builder.enum_field().set(TestEnum::Bar);
+}
+
+#[test]
+fn make_port() {
+    let src_value = ports::capnp_test_capnp::TestAllTypes {
+        bool_field: true,
+        int8_field: 7,
+        int16_field: 15,
+        int32_field: 31,
+        int64_field: 63,
+        u_int8_field: 8,
+        u_int16_field: 16,
+        u_int32_field: 32,
+        u_int64_field: 64,
+        float32_field: -32.32,
+        float64_field: -64.64,
+        text_field: Some(recapn_port::text::Text::new("Hello world!")),
+        data_field: Some(
+            recapn_port::data::Data::new(Box::from(b"Hello bytes!".as_slice())).unwrap()
+        ),
+        struct_field: Some(Box::new(ports::capnp_test_capnp::TestAllTypes {
+            float32_field: 32.32,
+            float64_field: 64.64,
+            ..Default::default()
+        })),
+        enum_field: recapn_port::Enum::from_type(ports::capnp_test_capnp::TestEnum::Bar),
+        ..Default::default()
+    };
+    let mut message = Message::global();
+    message.builder().into_root().serialize::<_, Box<dyn core::error::Error>>(&src_value).unwrap();
+    let dst_value: ports::capnp_test_capnp::TestAllTypes =
+        message.reader().root().deserialize::<_, Box<dyn core::error::Error>>().unwrap();
+
+    assert_eq!(src_value.bool_field, dst_value.bool_field);
+    assert_eq!(src_value.int8_field, dst_value.int8_field);
+    assert_eq!(src_value.int16_field, dst_value.int16_field);
+    assert_eq!(src_value.int32_field, dst_value.int32_field);
+    assert_eq!(src_value.int64_field, dst_value.int64_field);
+    assert_eq!(src_value.u_int32_field, dst_value.u_int32_field);
+    assert_eq!(src_value.float64_field, dst_value.float64_field);
 }
 
 #[test]

--- a/tests/src/ports/capnp/test-import.capnp.rs
+++ b/tests/src/ports/capnp/test-import.capnp.rs
@@ -1,0 +1,66 @@
+#![allow(unused, unsafe_code)]
+use super::{__file, __imports};
+pub struct TestImport {
+    pub field: Option<Box<__imports::capnp_test_capnp::TestAllTypes>>,
+}
+impl ::recapn::ty::SchemaType for TestImport {
+    const ID: u64 = 13570947164928695703u64;
+}
+impl ::recapn_port::Deserialize<'_, ::recapn::rpc::Empty> for TestImport {
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::StructReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<Self, E> {
+        Ok(Self {
+            field: ::recapn_port::deserialize(&r.ptr_field(0))?,
+        })
+    }
+}
+impl ::recapn_port::DeserializePtr<'_, ::recapn::rpc::Empty> for TestImport {
+    #[inline]
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::PtrReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<Self, E> {
+        ::recapn_port::deserialize_struct(r)
+    }
+}
+impl ::recapn_port::list::DeserializeList<'_, ::recapn::rpc::Empty> for TestImport {
+    #[inline]
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::PtrReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<::recapn_port::list::List<Self>, E> {
+        ::recapn_port::list::deserialize_struct_list(r)
+    }
+}
+impl ::recapn_port::Serialize<'_, ::recapn::rpc::Empty> for TestImport {
+    const SIZE: ::recapn::ptr::StructSize = ::recapn::ptr::StructSize {
+        data: 0,
+        ptrs: 1,
+    };
+    fn serialize<E: ::recapn_port::Error>(
+        &self,
+        b: &mut ::recapn::ptr::StructBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        if let Some(mut ptr) = b.ptr_field_mut(0) {
+            ::recapn_port::serialize(&self.field, ptr)?;
+        }
+        Ok(())
+    }
+}
+impl ::recapn_port::SerializePtr<'_, ::recapn::rpc::Empty> for TestImport {
+    #[inline]
+    fn serialize<E: ::recapn_port::Error>(
+        &self,
+        b: ::recapn::ptr::PtrBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        ::recapn_port::serialize_struct(self, b)
+    }
+}
+impl ::recapn_port::list::SerializeList<'_, ::recapn::rpc::Empty> for TestImport {
+    #[inline]
+    fn serialize<E: ::recapn_port::Error>(
+        s: &[Self],
+        b: recapn::ptr::PtrBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        ::recapn_port::list::serialize_struct_list(s, b)
+    }
+}

--- a/tests/src/ports/capnp/test-import2.capnp.rs
+++ b/tests/src/ports/capnp/test-import2.capnp.rs
@@ -1,0 +1,37 @@
+#![allow(unused, unsafe_code)]
+use super::{__file, __imports};
+pub struct TestImport2 {
+    pub foo: Option<Box<__imports::capnp_test_capnp::TestAllTypes>>,
+    pub bar: Option<Box<__imports::capnp_test_import_capnp::TestImport>>,
+}
+impl ::recapn::ty::SchemaType for TestImport2 {
+    const ID: u64 = 17779498780914921727u64;
+}
+impl ::recapn_port::Deserialize<'_, ::recapn::rpc::Empty> for TestImport2 {
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::StructReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<Self, E> {
+        Ok(Self {
+            foo: ::recapn_port::deserialize(&r.ptr_field(0))?,
+            bar: ::recapn_port::deserialize(&r.ptr_field(1))?,
+        })
+    }
+}
+impl ::recapn_port::Serialize<'_, ::recapn::rpc::Empty> for TestImport2 {
+    const SIZE: ::recapn::ptr::StructSize = ::recapn::ptr::StructSize {
+        data: 0u16,
+        ptrs: 2u16,
+    };
+    fn serialize<E: ::recapn_port::Error>(
+        &self,
+        b: &mut ::recapn::ptr::StructBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        if let Some(mut ptr) = b.ptr_field_mut(0) {
+            ::recapn_port::serialize(&self.foo, ptr)?;
+        }
+        if let Some(mut ptr) = b.ptr_field_mut(1) {
+            ::recapn_port::serialize(&self.bar, ptr)?;
+        }
+        Ok(())
+    }
+}

--- a/tests/src/ports/capnp/test.capnp.rs
+++ b/tests/src/ports/capnp/test.capnp.rs
@@ -1,0 +1,272 @@
+#![allow(unused, unsafe_code)]
+use super::{__file, __imports};
+#[repr(u16)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub enum TestEnum {
+    #[default]
+    Foo,
+    Bar,
+    Baz,
+    Qux,
+    Quux,
+    Corge,
+    Grault,
+    Garply,
+}
+impl ::recapn::ty::SchemaType for TestEnum {
+    const ID: u64 = 11281115850894843091u64;
+}
+impl core::convert::TryFrom<u16> for TestEnum {
+    type Error = ::recapn::NotInSchema;
+    #[inline]
+    fn try_from(value: u16) -> Result<Self, ::recapn::NotInSchema> {
+        match value {
+            0u16 => Ok(Self::Foo),
+            1u16 => Ok(Self::Bar),
+            2u16 => Ok(Self::Baz),
+            3u16 => Ok(Self::Qux),
+            4u16 => Ok(Self::Quux),
+            5u16 => Ok(Self::Corge),
+            6u16 => Ok(Self::Grault),
+            7u16 => Ok(Self::Garply),
+            value => Err(::recapn::NotInSchema(value)),
+        }
+    }
+}
+impl core::convert::From<TestEnum> for u16 {
+    #[inline]
+    fn from(value: TestEnum) -> Self {
+        value as u16
+    }
+}
+impl ::recapn::ty::Enum for TestEnum {}
+pub struct TestAllTypes {
+    pub void_field: (),
+    pub bool_field: bool,
+    pub int8_field: i8,
+    pub int16_field: i16,
+    pub int32_field: i32,
+    pub int64_field: i64,
+    pub u_int8_field: u8,
+    pub u_int16_field: u16,
+    pub u_int32_field: u32,
+    pub u_int64_field: u64,
+    pub float32_field: f32,
+    pub float64_field: f64,
+    pub text_field: Option<::recapn_port::text::Text>,
+    pub data_field: Option<::recapn_port::data::Data>,
+    pub struct_field: Option<Box<TestAllTypes>>,
+    pub enum_field: ::recapn_port::Enum<TestEnum>,
+    pub void_list: Option<::recapn_port::list::List<()>>,
+    pub bool_list: Option<::recapn_port::list::List<bool>>,
+    pub int8_list: Option<::recapn_port::list::List<i8>>,
+    pub int16_list: Option<::recapn_port::list::List<i16>>,
+    pub int32_list: Option<::recapn_port::list::List<i32>>,
+    pub int64_list: Option<::recapn_port::list::List<i64>>,
+    pub u_int8_list: Option<::recapn_port::list::List<u8>>,
+    pub u_int16_list: Option<::recapn_port::list::List<u16>>,
+    pub u_int32_list: Option<::recapn_port::list::List<u32>>,
+    pub u_int64_list: Option<::recapn_port::list::List<u64>>,
+    pub float32_list: Option<::recapn_port::list::List<f32>>,
+    pub float64_list: Option<::recapn_port::list::List<f64>>,
+    pub text_list: Option<::recapn_port::list::List<::recapn_port::text::Text>>,
+    pub data_list: Option<::recapn_port::list::List<::recapn_port::data::Data>>,
+    pub struct_list: Option<::recapn_port::list::List<TestAllTypes>>,
+    pub enum_list: Option<::recapn_port::list::List<::recapn_port::Enum<TestEnum>>>,
+}
+impl Default for TestAllTypes {
+    fn default() -> Self {
+        Self {
+            void_field: (),
+            bool_field: false,
+            int8_field: 0,
+            int16_field: 0,
+            int32_field: 0,
+            int64_field: 0,
+            u_int8_field: 0,
+            u_int16_field: 0,
+            u_int32_field: 0,
+            u_int64_field: 0,
+            float32_field: 0.,
+            float64_field: 0.,
+            text_field: None,
+            data_field: None,
+            struct_field: None,
+            enum_field: ::recapn_port::Enum::from_value(0),
+            void_list: None,
+            bool_list: None,
+            int8_list: None,
+            int16_list: None,
+            int32_list: None,
+            int64_list: None,
+            u_int8_list: None,
+            u_int16_list: None,
+            u_int32_list: None,
+            u_int64_list: None,
+            float32_list: None,
+            float64_list: None,
+            text_list: None,
+            data_list: None,
+            struct_list: None,
+            enum_list: None,
+        }
+    }
+}
+impl ::recapn::ty::SchemaType for TestAllTypes {
+    const ID: u64 = 11576770112468509693u64;
+}
+impl ::recapn_port::Deserialize<'_, ::recapn::rpc::Empty> for TestAllTypes {
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::StructReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<Self, E> {
+        Ok(Self {
+            void_field: {},
+            bool_field: { r.data_field_with_default(0, false) },
+            int8_field: { r.data_field_with_default(1, 0) },
+            int16_field: { r.data_field_with_default(1, 0) },
+            int32_field: { r.data_field_with_default(1, 0) },
+            int64_field: { r.data_field_with_default(1, 0) },
+            u_int8_field: { r.data_field_with_default(16, 0) },
+            u_int16_field: { r.data_field_with_default(9, 0) },
+            u_int32_field: { r.data_field_with_default(5, 0) },
+            u_int64_field: { r.data_field_with_default(3, 0) },
+            float32_field: { r.data_field_with_default(8, 0.) },
+            float64_field: { r.data_field_with_default(5, 0.) },
+            text_field: { ::recapn_port::deserialize(&r.ptr_field(0))? },
+            data_field: { ::recapn_port::deserialize(&r.ptr_field(1))? },
+            struct_field: { ::recapn_port::deserialize(&r.ptr_field(2))? },
+            enum_field: { ::recapn_port::Enum::from_value(r.data_field_with_default(18, 0)) },
+            void_list: { ::recapn_port::deserialize(&r.ptr_field(3))? },
+            bool_list: { ::recapn_port::deserialize(&r.ptr_field(4))? },
+            int8_list: { ::recapn_port::deserialize(&r.ptr_field(5))? },
+            int16_list: { ::recapn_port::deserialize(&r.ptr_field(6))? },
+            int32_list: { ::recapn_port::deserialize(&r.ptr_field(7))? },
+            int64_list: { ::recapn_port::deserialize(&r.ptr_field(8))? },
+            u_int8_list: { ::recapn_port::deserialize(&r.ptr_field(9))? },
+            u_int16_list: { ::recapn_port::deserialize(&r.ptr_field(10))? },
+            u_int32_list: { ::recapn_port::deserialize(&r.ptr_field(11))? },
+            u_int64_list: { ::recapn_port::deserialize(&r.ptr_field(12))? },
+            float32_list: { ::recapn_port::deserialize(&r.ptr_field(13))? },
+            float64_list: { ::recapn_port::deserialize(&r.ptr_field(14))? },
+            text_list: { ::recapn_port::deserialize(&r.ptr_field(15))? },
+            data_list: { ::recapn_port::deserialize(&r.ptr_field(16))? },
+            struct_list: { ::recapn_port::deserialize(&r.ptr_field(17))? },
+            enum_list: { ::recapn_port::deserialize(&r.ptr_field(18))? },
+        })
+    }
+}
+impl ::recapn_port::DeserializePtr<'_, ::recapn::rpc::Empty> for TestAllTypes {
+    #[inline]
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::PtrReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<Self, E> {
+        ::recapn_port::deserialize_struct(r)
+    }
+}
+impl ::recapn_port::list::DeserializeList<'_, ::recapn::rpc::Empty> for TestAllTypes {
+    #[inline]
+    fn deserialize<E: ::recapn_port::Error>(
+        r: &::recapn::ptr::PtrReader<'_, ::recapn::rpc::Empty>,
+    ) -> Result<::recapn_port::list::List<Self>, E> {
+        ::recapn_port::list::deserialize_struct_list(r)
+    }
+}
+impl ::recapn_port::Serialize<'_, ::recapn::rpc::Empty> for TestAllTypes {
+    const SIZE: ::recapn::ptr::StructSize = ::recapn::ptr::StructSize {
+        data: 6u16,
+        ptrs: 20u16,
+    };
+    fn serialize<E: ::recapn_port::Error>(
+        &self,
+        b: &mut ::recapn::ptr::StructBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        b.set_field_with_default(0, self.bool_field, false);
+        b.set_field_with_default(1, self.int8_field, 0);
+        b.set_field_with_default(1, self.int16_field, 0);
+        b.set_field_with_default(1, self.int32_field, 0);
+        b.set_field_with_default(1, self.int64_field, 0);
+        b.set_field_with_default(16, self.u_int8_field, 0);
+        b.set_field_with_default(9, self.u_int16_field, 0);
+        b.set_field_with_default(5, self.u_int32_field, 0);
+        b.set_field_with_default(3, self.u_int64_field, 0);
+        b.set_field_with_default(8, self.float32_field, 0.);
+        b.set_field_with_default(5, self.float64_field, 0.);
+        if let Some(ptr) = b.ptr_field_mut(0) {
+            ::recapn_port::serialize(&self.text_field, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(1) {
+            ::recapn_port::serialize(&self.data_field, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(2) {
+            ::recapn_port::serialize(&self.struct_field, ptr)?;
+        }
+        b.set_field_with_default(18, self.enum_field.into_value(), 0);
+        if let Some(ptr) = b.ptr_field_mut(3) {
+            ::recapn_port::serialize(&self.void_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(4) {
+            ::recapn_port::serialize(&self.bool_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(5) {
+            ::recapn_port::serialize(&self.int8_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(6) {
+            ::recapn_port::serialize(&self.int16_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(7) {
+            ::recapn_port::serialize(&self.int32_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(8) {
+            ::recapn_port::serialize(&self.int64_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(9) {
+            ::recapn_port::serialize(&self.u_int8_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(10) {
+            ::recapn_port::serialize(&self.u_int16_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(11) {
+            ::recapn_port::serialize(&self.u_int32_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(12) {
+            ::recapn_port::serialize(&self.u_int64_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(13) {
+            ::recapn_port::serialize(&self.float32_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(14) {
+            ::recapn_port::serialize(&self.float64_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(15) {
+            ::recapn_port::serialize(&self.text_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(16) {
+            ::recapn_port::serialize(&self.data_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(17) {
+            ::recapn_port::serialize(&self.struct_list, ptr)?;
+        }
+        if let Some(ptr) = b.ptr_field_mut(18) {
+            ::recapn_port::serialize(&self.enum_list, ptr)?;
+        }
+        Ok(())
+    }
+}
+impl ::recapn_port::SerializePtr<'_, ::recapn::rpc::Empty> for TestAllTypes {
+    #[inline]
+    fn serialize<E: ::recapn_port::Error>(
+        &self,
+        b: ::recapn::ptr::PtrBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        ::recapn_port::serialize_struct(self, b)
+    }
+}
+impl ::recapn_port::list::SerializeList<'_, ::recapn::rpc::Empty> for TestAllTypes {
+    #[inline]
+    fn serialize<E: ::recapn_port::Error>(
+        this: &[Self],
+        b: ::recapn::ptr::PtrBuilder<'_, ::recapn::rpc::Empty>,
+    ) -> Result<(), E> {
+        ::recapn_port::list::serialize_struct_list(this, b)
+    }
+}

--- a/tests/src/ports/mod.rs
+++ b/tests/src/ports/mod.rs
@@ -1,0 +1,32 @@
+#[path = "."]
+pub mod capnp_test_capnp {
+    #![allow(unused_imports)]
+    use super::capnp_test_capnp as __file;
+    mod __imports {}
+    #[path = "capnp/test.capnp.rs"]
+    mod capnp_test_capnp;
+    pub use capnp_test_capnp::*;
+}
+#[path = "."]
+pub mod capnp_test_import_capnp {
+    #![allow(unused_imports)]
+    use super::capnp_test_import_capnp as __file;
+    mod __imports {
+        pub use super::super::capnp_test_capnp;
+    }
+    #[path = "capnp/test-import.capnp.rs"]
+    mod capnp_test_import_capnp;
+    pub use capnp_test_import_capnp::*;
+}
+#[path = "."]
+pub mod capnp_test_import2_capnp {
+    #![allow(unused_imports)]
+    use super::capnp_test_import2_capnp as __file;
+    mod __imports {
+        pub use super::super::capnp_test_capnp;
+        pub use super::super::capnp_test_import_capnp;
+    }
+    #[path = "capnp/test-import2.capnp.rs"]
+    mod capnp_test_import2_capnp;
+    pub use capnp_test_import2_capnp::*;
+}


### PR DESCRIPTION
Adds support for a new method of generating "Plain Old Rust Types", or "PORT" types based on capnp schemas.

recapn-port is meant to be a single-pass de/serialization system more akin to serde vs the standard zero-copy method Cap'n Proto libraries use. This makes the types easily movable and modifiable, but at the cost that you lose backwards compability if you need to *reserialize*.

This is built on top of recapn, so you can use either one interchangably. They will have different code generators though, which might make juggling a little complicated.